### PR TITLE
Add schema title

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -19,6 +19,7 @@ declare module '@sanity/types' {
 }
 
 export const latexSchema = defineType({
+  title: 'Latex',
   type: 'object',
   name: 'latex',
   components: { preview: LatexPreview },


### PR DESCRIPTION
Studio started complaining about missing schema title.

=> This PR adds a title to the latex object schema type.

<img width="834" alt="Screenshot 2023-03-16 at 23 48 14" src="https://user-images.githubusercontent.com/29004228/225769650-03a9bb46-2281-4aa7-8666-038ea9f75116.png">
