### PR TITLE
fix(deps): allow studio v4 in peer dep ranges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
   pull_request:
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
-    branches: [main,studio-v2]
+    branches: [main, studio-v2]
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
     inputs:
@@ -106,27 +106,27 @@ jobs:
     runs-on: ubuntu-latest
     name: Semantic release
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v4
         with:
           # Need to fetch entire commit history to
           # analyze every commit since last release
           fetch-depth: 0
-      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+          # Uses generated token to allow pushing commits back
+          token: ${{ steps.app-token.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+      - uses: actions/setup-node@v4
         with:
           cache: npm
           node-version: lts/*
       - run: npm ci
         # Branches that will release new versions are defined in .releaserc.json
       - run: npx semantic-release
-        # Don't allow interrupting the release step if the job is cancelled, as it can lead to an inconsistent state
-        # e.g. git tags were pushed but it exited before `npm publish`
-        if: always()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        # Re-run semantic release with rich logs if it failed to publish for easier debugging
-      - run: npx semantic-release --dry-run --debug
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
       "peerDependencies": {
         "react": "^18",
         "react-dom": "^18",
-        "sanity": "^3.0.0"
+        "sanity": "^3.0.0 || ^4.0.0-0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "peerDependencies": {
     "react": "^18",
     "react-dom": "^18",
-    "sanity": "^3.0.0"
+    "sanity": "^3.0.0 || ^4.0.0-0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION

### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```json
{
  "dependencies": {
    "sanity": "4.0.0-0"
  }
}
```
Running `pnpm install --resolution-only` yields peer dep issues:
```bash
❯ pnpm install --resolution-only --ignore-workspace
Progress: resolved 1032, reused 0, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ sanity-plugin-latex-input 2.0.5
  └── ✕ unmet peer sanity@^3.0.0: found 4.0.0-0
Done in 7.6s using pnpm v10.12.1
```
This fixes it.

### Testing

Tested locally